### PR TITLE
Add wally package

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ spr is a single-module library.
 
 Documentation on how to use ModuleScripts can be found [here.](https://developer.roblox.com/en-us/api-reference/class/ModuleScript)
 
+### wally
+
+1. Setup a wally project, you can find information about that [here](https://github.com/upliftgames/wally).
+2. Add ``Spr = "eldonwilliams/spr@^0.1.0"`` to your `wally.toml` file
+3. Run ``wally install`` and you should be good to go!
+
 ### roblox-ts
 
 roblox-ts bindings for spr can be installed [here.](https://www.npmjs.com/package/@rbxts/spr)

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,0 +1,3 @@
+[tools]
+rojo = { source = "rojo-rbx/rojo", version = "7.0.0" }
+wally = { source = "UpliftGames/wally", version = "0.3.1" }

--- a/spr.lua
+++ b/spr.lua
@@ -394,7 +394,7 @@ local typeMetadata = {
 		end,
 
 		fromIntermediate = function(value)
-			return CFrame.new(unpack(value))
+			return CFrame.new(unpack(value)):Orthonormalize()
 		end,
 	},
 

--- a/spr.lua
+++ b/spr.lua
@@ -385,6 +385,30 @@ local typeMetadata = {
 			)
 		end,
 	},
+
+	CFrame = {
+		springType = LinearSpring.new,
+
+		toIntermediate = function(value)
+			return {value:GetComponents()}
+		end,
+
+		fromIntermediate = function(value)
+			return CFrame.new(unpack(value))
+		end,
+	},
+
+	boolean = {
+		springType = LinearSpring.new,
+
+		toIntermediate = function(value)
+			return {value and 1 or 0}
+		end,
+
+		fromIntermediate = function(value)
+			return value[1] >= 0 or false
+		end,
+	},
 }
 
 local springStates = {} -- {[instance] = {[property] = spring}

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eldonwilliams/spr"
 version = "0.1.1"
-description = "Spr module as a wally package"
+description = "Spr module as a wally package w/ added support for "
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eldonwilliams/spr"
-version = "0.2.0"
+version = "0.2.1"
 description = "Spr module as a wally package w/ added support for "
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eldonwilliams/spr"
-version = "0.1.1"
+version = "0.2.0"
 description = "Spr module as a wally package w/ added support for "
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"

--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,8 @@
+[package]
+name = "eldonwilliams/spr"
+version = "0.1.1"
+description = "Spr module as a wally package"
+registry = "https://github.com/UpliftGames/wally-index"
+realm = "shared"
+
+[dependencies]


### PR DESCRIPTION
I published this package as eldonwilliams/spr if you want to use it right now, but I would like to see this merged to master and published under fraktality/spr.

*When this is merged, README.md will have to have the wally installation instructions tweaked slightly.*