### PR TITLE
Stop should cancel "completed" callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ spr.stop(obj: Instance, property: string?)
 Stops animations for a particular property.
 If a property is not specified, all properties belonging to the instance will stop animating.
 
+Additionally, this also cancels any 'completed' callbacks associated
+
 ## Spring fundamentals
 
 Damping ratio and undamped frequency are the two properties describing a spring's motion.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ spr.stop(obj: Instance, property: string?)
 
 Stops animations for a particular property.
 If a property is not specified, all properties belonging to the instance will stop animating.
-
-Additionally, this also cancels any 'completed' callbacks associated
+Any completed callbacks associated with the instance will be canceled.
 
 ## Spring fundamentals
 

--- a/spr.lua
+++ b/spr.lua
@@ -819,6 +819,10 @@ function spr.stop(instance: Instance, property: string?)
 		springStates_other[instance] = nil
 		springStates_render[instance] = nil
 	end
+
+	if completedCallbacks[instance] then
+		completedCallbacks[instance] = nil
+	end
 end
 
 function spr.completed(instance: Instance, callback: ()->())


### PR DESCRIPTION
I have encountered various issues when using the spr.completed method due to the lack of a way to cancel those callbacks. All these problems could be resolved by allowing the stop method to cancel the associated 'completed' callbacks.